### PR TITLE
Fix SSPAI image host remapping

### DIFF
--- a/lib/getMediaCtx.ts
+++ b/lib/getMediaCtx.ts
@@ -1,5 +1,7 @@
+import { normalizeAssetUrl } from "./normalizeAssetUrl"
+
 export const getMediaCtx = (value: any) => {
-    const src = value.type === 'external' ? value.external.url : value.file.url
+    const src = normalizeAssetUrl(value.type === 'external' ? value.external.url : value.file.url)
     const expire = value.type === 'file' ? value.file.expiry_time : null
     const caption = value.caption ? value.caption : []
     

--- a/lib/normalizeAssetUrl.ts
+++ b/lib/normalizeAssetUrl.ts
@@ -1,0 +1,19 @@
+const HOST_REMAPS: Record<string, string> = {
+  "cdn.sspai.com": "cdnfile.sspai.com",
+}
+
+export const normalizeAssetUrl = (raw?: string | null) => {
+  if (!raw) return raw || ""
+
+  try {
+    const url = new URL(raw)
+    const mappedHost = HOST_REMAPS[url.hostname]
+    if (mappedHost) {
+      url.hostname = mappedHost
+      url.protocol = "https:"
+    }
+    return url.toString()
+  } catch {
+    return raw
+  }
+}

--- a/lib/notion.ts
+++ b/lib/notion.ts
@@ -1,5 +1,6 @@
 import { Client } from '@notionhq/client'
 import { Post } from './types'
+import { normalizeAssetUrl } from './normalizeAssetUrl'
 
 const notion = new Client({ auth: process.env.NOTION_KEY })
 const databaseId = process.env.NOTION_DATABASE_ID || '7fddb522451e4ac68922d1515da1f5f4'
@@ -60,8 +61,8 @@ export const getDatabase = async (slug?: string) => {
             const updateDate = properties.UpdateDate.type === "last_edited_time" && properties.UpdateDate.last_edited_time
 
             const undefinedCover = "https://cdn.dribbble.com/users/3167939/screenshots/10422336/media/b618a0e73996c3b24b58b2db1c881ee3.png"
-            const cover_light = properties.Cover.type === "url" && properties.Cover.url || undefinedCover
-            const cover_dark = properties.Cover_dark.type === "url" && properties.Cover_dark.url || cover_light
+            const cover_light = normalizeAssetUrl(properties.Cover.type === "url" && properties.Cover.url || undefinedCover)
+            const cover_dark = normalizeAssetUrl(properties.Cover_dark.type === "url" && properties.Cover_dark.url || cover_light)
             const cover = { light: cover_light, dark: cover_dark }
 
             const category = properties.Category.type === "select" && { name: properties.Category.select?.name, color: properties.Category.select?.color }

--- a/lib/probeImageSize.ts
+++ b/lib/probeImageSize.ts
@@ -1,7 +1,8 @@
 import probe from 'probe-image-size'
+import { normalizeAssetUrl } from './normalizeAssetUrl'
 
 const probeImageSize = async (url: string) => {
-    const size = await probe(url)
+    const size = await probe(normalizeAssetUrl(url))
     return { width: size.width, height: size.height }
 }
 

--- a/next.config.js
+++ b/next.config.js
@@ -15,7 +15,7 @@ module.exports = withPWA(
       return config
     },
     images: {
-      domains: ['static.anzifan.com', 'cdn.sspai.com', 'cdn.dribbble.com', 'image.freepik.com', 'avatars.githubusercontent.com', 'cdn.jsdelivr.net', 'image.cugxuan.cn', 'blog-static.mikuchan.top', 'amazonaws.com', 'img.zhheo.com', 'www.aohuiliu.fun', 'rxhsk.xicp.fun', 'www.fomal.cc'],
+      domains: ['static.anzifan.com', 'cdn.sspai.com', 'cdnfile.sspai.com', 'cdn.dribbble.com', 'image.freepik.com', 'avatars.githubusercontent.com', 'cdn.jsdelivr.net', 'image.cugxuan.cn', 'blog-static.mikuchan.top', 'amazonaws.com', 'img.zhheo.com', 'www.aohuiliu.fun', 'rxhsk.xicp.fun', 'www.fomal.cc'],
     },
     pwa: {
       dest: "public",

--- a/pages/post/[slug].tsx
+++ b/pages/post/[slug].tsx
@@ -31,6 +31,7 @@ import { Post } from "../../lib/types";
 import readingTime from "reading-time";
 import PostSeo from "../../components/PostSeo";
 import { useRouter } from "next/router";
+import { normalizeAssetUrl } from "../../lib/normalizeAssetUrl";
 
 const PostPage: NextPage<{ page: Post; blocks: any[]; pagination: any; posts: any; setToc : Dispatch<SetStateAction<any>> }> = ({ page, blocks, pagination, posts, setToc }) => {
     const { text } = readingTime(blocks.map(b => b.paragraph?.text?.map((t: any) => t.text?.content)).join(""));
@@ -233,7 +234,7 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
             .map(async b => {
                 const { type } = b
                 const value = b[type]
-                const src = value.type === 'external' ? value.external.url : value.file.url
+                const src = normalizeAssetUrl(value.type === 'external' ? value.external.url : value.file.url)
                 const { width, height } = await probeImageSize(src)
                 const blur = (await getPlaiceholder(src, {
                     size: 10,
@@ -255,7 +256,7 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
                         .map(async (b: any) => {
                             const { type } = b
                             const value = b[type]
-                            const src = value.type === 'external' ? value.external.url : value.file.url
+                            const src = normalizeAssetUrl(value.type === 'external' ? value.external.url : value.file.url)
                             const { width, height } = await probeImageSize(src)
                             const blur = (await getPlaiceholder(src, {
                                 size: 10,
@@ -282,7 +283,7 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
                                     .map(async (b: any) => {
                                         const { type } = b
                                         const value = b[type]
-                                        const src = value.type === 'external' ? value.external.url : value.file.url
+                                        const src = normalizeAssetUrl(value.type === 'external' ? value.external.url : value.file.url)
                                         const { width, height } = await probeImageSize(src)
                                         const blur = (await getPlaiceholder(src, {
                                             size: 10,


### PR DESCRIPTION
## Summary\n- remap legacy SSPAI image URLs from cdn.sspai.com to cdnfile.sspai.com\n- normalize Notion cover and block media URLs before image probing and placeholder generation\n- allow the new SSPAI host in Next image domains\n\n## Verification\n- yarn lint (passes; only pre-existing warnings remain)