### PR TITLE
Make remote image placeholders resilient

### DIFF
--- a/lib/imagePlaceholders.ts
+++ b/lib/imagePlaceholders.ts
@@ -1,0 +1,72 @@
+import { getPlaiceholder } from "plaiceholder"
+import { normalizeAssetUrl } from "./normalizeAssetUrl"
+
+const REMOTE_PROTOCOLS = new Set(["http:", "https:"])
+const HOTLINK_PROTECTED_HOSTS = new Set(["cdn.sspai.com", "cdnfile.sspai.com"])
+const DEFAULT_PLACEHOLDER_SIZE = 10
+const BUILD_USER_AGENT = "Mozilla/5.0 (compatible; anzifan-build/1.0; +https://www.anzifan.com/)"
+
+const getRemoteRequestHeaders = (url: URL) => {
+    const headers: Record<string, string> = {
+        "User-Agent": BUILD_USER_AGENT,
+        "Accept": "*/*",
+    }
+
+    if (HOTLINK_PROTECTED_HOSTS.has(url.hostname)) {
+        headers["Referer"] = "https://www.anzifan.com/"
+    }
+
+    return headers
+}
+
+const loadImageInput = async (raw: string) => {
+    const src = normalizeAssetUrl(raw)
+
+    try {
+        const url = new URL(src)
+        if (REMOTE_PROTOCOLS.has(url.protocol)) {
+            const response = await fetch(url.toString(), {
+                headers: getRemoteRequestHeaders(url),
+            })
+
+            if (!response.ok) {
+                throw new Error(`Failed to fetch ${url.toString()} (${response.status})`)
+            }
+
+            return {
+                src,
+                input: Buffer.from(await response.arrayBuffer()),
+            }
+        }
+    } catch (error) {
+        if (error instanceof TypeError) {
+            return { src, input: src }
+        }
+
+        throw error
+    }
+
+    return { src, input: src }
+}
+
+export const getImageBlurDataURL = async (raw: string, size = DEFAULT_PLACEHOLDER_SIZE) => {
+    const { input } = await loadImageInput(raw)
+    const { base64 } = await getPlaiceholder(input, { size })
+    return base64
+}
+
+export const getImageMetadata = async (raw: string, size = DEFAULT_PLACEHOLDER_SIZE) => {
+    const { src, input } = await loadImageInput(raw)
+    const { base64, img } = await getPlaiceholder(input, { size })
+
+    if (!img.width || !img.height) {
+        throw new Error(`Missing image dimensions for ${src}`)
+    }
+
+    return {
+        src,
+        width: img.width,
+        height: img.height,
+        blur: base64,
+    }
+}

--- a/pages/archive.tsx
+++ b/pages/archive.tsx
@@ -1,7 +1,6 @@
 import Moment from "react-moment";
 import { GetStaticProps, NextPage } from "next";
 import Link from "next/link";
-import { getPlaiceholder } from "plaiceholder";
 import { Colors } from "../lib/colors";
 import { getDatabase } from "../lib/notion";
 import { Post } from "../lib/types";
@@ -9,6 +8,7 @@ import Image from "next/image";
 import { FullListLayout } from "../components/layout/ListLayout";
 import moment from "moment";
 import ThemedImage from "../components/ThemedImage";
+import { getImageBlurDataURL } from "../lib/imagePlaceholders";
 
 // TODO: Add pagination and filter
 
@@ -68,12 +68,8 @@ export const getStaticProps: GetStaticProps = async () => {
     for (let post of db) {
         if (post) {
             try {
-                post.cover.blurLight = (await getPlaiceholder(post.cover.light, {
-                    size: 10,
-                })).base64
-                post.cover.blurDark = (await getPlaiceholder(post.cover.dark, {
-                    size: 10,
-                })).base64
+                post.cover.blurLight = await getImageBlurDataURL(post.cover.light)
+                post.cover.blurDark = await getImageBlurDataURL(post.cover.dark)
             } catch (e) {
                 post.cover.blurLight = ''
                 post.cover.blurDark = ''

--- a/pages/category/[cate].tsx
+++ b/pages/category/[cate].tsx
@@ -2,8 +2,8 @@ import { GetStaticProps, NextPage } from "next"
 import PostList from "../../components/PostList"
 import { getDatabase } from "../../lib/notion"
 import { Post, Tag } from "../../lib/types"
-import { getPlaiceholder } from "plaiceholder";
 import { ParsedUrlQuery } from "querystring";
+import { getImageBlurDataURL } from "../../lib/imagePlaceholders";
 
 const CatePage: NextPage<{ posts: Post[], cate: Tag }> = ({ posts, cate }) => {
 
@@ -45,12 +45,8 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
     for (let post of db) {
         if (post) {
             try {
-                post.cover.blurLight = (await getPlaiceholder(post.cover.light, {
-                    size: 10,
-                })).base64
-                post.cover.blurDark = (await getPlaiceholder(post.cover.dark, {
-                    size: 10,
-                })).base64
+                post.cover.blurLight = await getImageBlurDataURL(post.cover.light)
+                post.cover.blurDark = await getImageBlurDataURL(post.cover.dark)
             } catch (e) {
                 post.cover.blurLight = ''
                 post.cover.blurDark = ''

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -9,7 +9,6 @@ import { getDatabase } from '../lib/notion'
 import PostList from '../components/PostList'
 import { Post } from '../lib/types'
 
-import { getPlaiceholder } from "plaiceholder";
 import { WidgetMeMedium, WidgetMeSmall } from '../components/widget/WidgetMe'
 import ListLayout from '../components/layout/ListLayout'
 import { WidgetOverViewMedium, WidgetOverViewSmall } from '../components/widget/WidgetOverview'
@@ -17,6 +16,7 @@ import { Media, MediaContextProvider } from '../components/utility/Breakpoints'
 import { NextSeo } from 'next-seo'
 import { useRouter } from 'next/router'
 import { me } from '../config/me'
+import { getImageBlurDataURL } from '../lib/imagePlaceholders'
 
 // type PostResult = QueryDatabaseResponse['results'][number];
 
@@ -67,12 +67,8 @@ export const getStaticProps: GetStaticProps = async () => {
   for (let post of db) {
     if (post) {
       try {
-        post.cover.blurLight = (await getPlaiceholder(post.cover.light, {
-          size: 10,
-        })).base64
-        post.cover.blurDark = (await getPlaiceholder(post.cover.dark, {
-          size: 10,
-        })).base64
+        post.cover.blurLight = await getImageBlurDataURL(post.cover.light)
+        post.cover.blurDark = await getImageBlurDataURL(post.cover.dark)
       } catch (e) {
         post.cover.blurLight = ''
         post.cover.blurDark = ''

--- a/pages/post/[slug].tsx
+++ b/pages/post/[slug].tsx
@@ -6,14 +6,12 @@ import { renderNotionBlock } from "../../components/NotionBlockRenderer"
 import ContentLayout, { CoverLayout } from "../../components/layout/ContentLayout"
 import Head from "next/head"
 import DefaultErrorPage from 'next/error'
-import probeImageSize from "../../lib/probeImageSize"
 import { BlogLayoutWhite } from "../../components/layout/BlogLayout"
 import type { ReactElement } from 'react'
 import { NextPageWithLayout } from "../_app"
 import Moment from "react-moment"
 import Link from "next/link"
 import { Colors } from "../../lib/colors"
-import { getPlaiceholder } from "plaiceholder";
 import { Share } from "../../components/Share";
 import Licensing from "../../components/Licensing";
 import TagsIcon from '../../assets/tags.svg'
@@ -32,6 +30,7 @@ import readingTime from "reading-time";
 import PostSeo from "../../components/PostSeo";
 import { useRouter } from "next/router";
 import { normalizeAssetUrl } from "../../lib/normalizeAssetUrl";
+import { getImageBlurDataURL, getImageMetadata } from "../../lib/imagePlaceholders";
 
 const PostPage: NextPage<{ page: Post; blocks: any[]; pagination: any; posts: any; setToc : Dispatch<SetStateAction<any>> }> = ({ page, blocks, pagination, posts, setToc }) => {
     const { text } = readingTime(blocks.map(b => b.paragraph?.text?.map((t: any) => t.text?.content)).join(""));
@@ -170,22 +169,28 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
     const prev = db[pageIndex - 1] || null
     const next = db[pageIndex + 1] || null
 
+    const setCoverBlur = async (post: Post | null) => {
+        if (!post) return
+
+        try {
+            post.cover.blurLight = await getImageBlurDataURL(post.cover.light)
+        } catch (error) {
+            post.cover.blurLight = ''
+        }
+
+        try {
+            post.cover.blurDark = await getImageBlurDataURL(post.cover.dark)
+        } catch (error) {
+            post.cover.blurDark = ''
+        }
+    }
+
     if (prev) {
-        prev.cover.blurLight = (await getPlaiceholder(prev.cover.light, {
-            size: 10,
-        })).base64
-        prev.cover.blurDark = (await getPlaiceholder(prev.cover.dark, {
-            size: 10,
-        })).base64
+        await setCoverBlur(prev)
     }
 
     if (next) {
-        next.cover.blurLight = (await getPlaiceholder(next.cover.light, {
-            size: 10,
-        })).base64
-        next.cover.blurDark = (await getPlaiceholder(next.cover.dark, {
-            size: 10,
-        })).base64
+        await setCoverBlur(next)
     }
 
     const pagination: any = {
@@ -197,12 +202,7 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
 
 
     if (page) {
-        page.cover.blurLight = (await getPlaiceholder(page.cover.light, {
-            size: 10,
-        })).base64
-        page.cover.blurDark = (await getPlaiceholder(page.cover.dark, {
-            size: 10,
-        })).base64
+        await setCoverBlur(page)
     }
 
 
@@ -235,12 +235,14 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
                 const { type } = b
                 const value = b[type]
                 const src = normalizeAssetUrl(value.type === 'external' ? value.external.url : value.file.url)
-                const { width, height } = await probeImageSize(src)
-                const blur = (await getPlaiceholder(src, {
-                    size: 10,
-                })).base64
-                value['size'] = { width, height }
-                value['blur'] = blur
+                try {
+                    const { width, height, blur } = await getImageMetadata(src)
+                    value['size'] = { width, height }
+                    value['blur'] = blur
+                } catch (error) {
+                    value['size'] = { width: 0, height: 0 }
+                    value['blur'] = ''
+                }
                 b[type] = value
             })
     )
@@ -257,12 +259,14 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
                             const { type } = b
                             const value = b[type]
                             const src = normalizeAssetUrl(value.type === 'external' ? value.external.url : value.file.url)
-                            const { width, height } = await probeImageSize(src)
-                            const blur = (await getPlaiceholder(src, {
-                                size: 10,
-                            })).base64
-                            value['size'] = { width, height }
-                            value['blur'] = blur
+                            try {
+                                const { width, height, blur } = await getImageMetadata(src)
+                                value['size'] = { width, height }
+                                value['blur'] = blur
+                            } catch (error) {
+                                value['size'] = { width: 0, height: 0 }
+                                value['blur'] = ''
+                            }
                             b[type] = value
                         })
             })
@@ -284,12 +288,14 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
                                         const { type } = b
                                         const value = b[type]
                                         const src = normalizeAssetUrl(value.type === 'external' ? value.external.url : value.file.url)
-                                        const { width, height } = await probeImageSize(src)
-                                        const blur = (await getPlaiceholder(src, {
-                                            size: 10,
-                                        })).base64
-                                        value['size'] = { width, height }
-                                        value['blur'] = blur
+                                        try {
+                                            const { width, height, blur } = await getImageMetadata(src)
+                                            value['size'] = { width, height }
+                                            value['blur'] = blur
+                                        } catch (error) {
+                                            value['size'] = { width: 0, height: 0 }
+                                            value['blur'] = ''
+                                        }
                                         b[type] = value
                                     })
                             )

--- a/pages/tag/[tag].tsx
+++ b/pages/tag/[tag].tsx
@@ -2,8 +2,8 @@ import { GetStaticProps, NextPage } from "next"
 import PostList from "../../components/PostList"
 import { getDatabase } from "../../lib/notion"
 import { Post, Tag } from "../../lib/types"
-import { getPlaiceholder } from "plaiceholder";
 import { ParsedUrlQuery } from "querystring";
+import { getImageBlurDataURL } from "../../lib/imagePlaceholders";
 
 const TagPage: NextPage<{ posts: Post[], tag: Tag }> = ({ posts, tag }) => {
 
@@ -45,12 +45,8 @@ export const getStaticProps: GetStaticProps = async ({params}) => {
     for (let post of db) {    
       if (post) {
         try {
-        post.cover.blurLight = (await getPlaiceholder(post.cover.light, {
-          size: 10,
-        })).base64
-        post.cover.blurDark = (await getPlaiceholder(post.cover.dark, {
-          size: 10,       
-        })).base64
+        post.cover.blurLight = await getImageBlurDataURL(post.cover.light)
+        post.cover.blurDark = await getImageBlurDataURL(post.cover.dark)
       } catch (e) {
         post.cover.blurLight = ''
         post.cover.blurDark = ''


### PR DESCRIPTION
## Summary\n- add a shared image placeholder helper that fetches remote images with build-safe headers\n- make cover placeholder generation tolerate remote fetch failures instead of failing the build\n- make post image metadata/blur generation fall back to empty placeholder data when a remote image cannot be fetched\n\n## Verification\n- yarn lint\n- ./node_modules/.bin/tsc --noEmit