### PR TITLE
Bypass optimization for SSPAI images

### DIFF
--- a/components/ThemedImage.tsx
+++ b/components/ThemedImage.tsx
@@ -1,6 +1,7 @@
 import Image from 'next/image'
 import { useTheme } from 'next-themes'
 import { useEffect, useState } from 'react'
+import { shouldBypassImageOptimization } from '../lib/shouldBypassImageOptimization'
 
 function ThemedImage(params: any) {
     const { resolvedTheme } = useTheme()
@@ -9,29 +10,36 @@ function ThemedImage(params: any) {
         setMounted(true)
     }, [])
 
+    const shouldBypassLightOptimization = shouldBypassImageOptimization(params.post.cover.light)
+
     if (!mounted) {
         return <Image src={params.post.cover.light} quality={params.quality || 100} layout="fill" objectFit="cover" sizes="100%" alt={params.post.title}
         // onLoadingComplete={handleLoad}
         placeholder="blur"
         blurDataURL={params.post.cover.blurLight}
+        unoptimized={shouldBypassLightOptimization}
         className={params.className} />
     }
 
     const emptyImage = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7'
     let src
     let blurSrc
+    let unoptimized = false
     switch (resolvedTheme) {
         case 'light':
             src = params.post.cover.light
             blurSrc = params.post.cover.blurLight
+            unoptimized = shouldBypassImageOptimization(src)
             break
         case 'dark':
             src = params.post.cover.dark
             blurSrc = params.post.cover.blurDark
+            unoptimized = shouldBypassImageOptimization(src)
             break
         default:
             src = emptyImage
             blurSrc = emptyImage
+            unoptimized = false
             break
     }
 
@@ -39,6 +47,7 @@ function ThemedImage(params: any) {
         // onLoadingComplete={handleLoad}
         placeholder="blur"
         blurDataURL={blurSrc}
+        unoptimized={unoptimized}
         className={params.className} />
 }
 

--- a/components/notionBlocks/NotionImage.tsx
+++ b/components/notionBlocks/NotionImage.tsx
@@ -2,6 +2,7 @@ import { getMediaCtx } from "../../lib/getMediaCtx"
 import Image from "next/image"
 import { NotionText } from "./NotionTextBlock"
 import { useState } from "react"
+import { shouldBypassImageOptimization } from "../../lib/shouldBypassImageOptimization"
 
 const NotionImage = ({ value }: { value: any }) => {
     let { src: imageSrc, caption: imageCaption, expire } = getMediaCtx(value)
@@ -25,6 +26,7 @@ const NotionImage = ({ value }: { value: any }) => {
     // };
 
     imageSrc = imageSrc.split('?')[0]
+    const unoptimized = shouldBypassImageOptimization(imageSrc)
 
     return (
         <figure className="mx-auto my-6 max-w-11/12 rounded-2xl" data-aos="fade-up" data-aos-duration="800" >
@@ -40,8 +42,9 @@ const NotionImage = ({ value }: { value: any }) => {
                         <Image className="rounded-2xl overflow-hidden" src={imageSrc} alt={imageCaption} width={width} height={height}
                             placeholder="blur"
                             blurDataURL={value.blur}
+                            unoptimized={unoptimized}
                         // onLoad={handleLoad}
-                        /> : <Image className="rounded-2xl overflow-hidden" src={imageSrc} alt={imageCaption} width={width} height={height} /> : <img className="rounded-2xl overflow-hidden" src={imageSrc} alt={imageCaption} width={width} height={height} />
+                        /> : <Image className="rounded-2xl overflow-hidden" src={imageSrc} alt={imageCaption} width={width} height={height} unoptimized={unoptimized} /> : <img className="rounded-2xl overflow-hidden" src={imageSrc} alt={imageCaption} width={width} height={height} />
                 ) : (
                     <img className="rounded-2xl overflow-hidden" src={imageSrc} alt={imageCaption} />
                 )}

--- a/lib/shouldBypassImageOptimization.ts
+++ b/lib/shouldBypassImageOptimization.ts
@@ -1,0 +1,15 @@
+const BYPASS_IMAGE_OPTIMIZATION_HOSTS = new Set([
+    "cdn.sspai.com",
+    "cdnfile.sspai.com",
+])
+
+export const shouldBypassImageOptimization = (raw?: string | null) => {
+    if (!raw) return false
+
+    try {
+        const url = new URL(raw)
+        return BYPASS_IMAGE_OPTIMIZATION_HOSTS.has(url.hostname)
+    } catch {
+        return false
+    }
+}


### PR DESCRIPTION
## Summary\n- bypass Next image optimization for images hosted on cdn.sspai.com and cdnfile.sspai.com\n- keep using Next Image for layout/placeholder behavior while letting the browser request the original image directly\n- remove the remaining dependency on the temporary Cloudflare Worker for SSPAI image optimizer requests\n\n## Verification\n- yarn lint\n- ./node_modules/.bin/tsc --noEmit